### PR TITLE
More test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 testtools/testrunner.py
 testtools/stub_dummytests.py
 tests/stubs
+waveform
 
 # Log files
 *.log

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ STUB_FILES = $(foreach t,$(VERILOG_MODULES),$(shell echo tests/stubs/$(t).py | t
 
 TEST_MODULES ?= $(VERILOG_MODULES)
 
+# Option to disable stub-generation (takes a lot of time)
+STUBS ?= on
+ifeq ($(STUBS), "on")
+	USE_STUBS = $(STUB_FILES)
+else
+	USE_STUBS =
+endif
+
 .PHONY : synth flash test clean rmbuild rmgen rmlogs shell stubs
 
 build/top_$(TARGET).bit: $(VERILOG_SOURCES)
@@ -88,6 +96,6 @@ build/file_compile_order.txt: scripts/dependency.tcl $(VERILOG_SOURCES)
 	mkdir -p build
 	vivado -mode batch -journal /dev/null -log /dev/null -source scripts/dependency.tcl 2>&1 >/dev/null
 
-test: build/file_compile_order.txt $(STUB_FILES)
+test: build/file_compile_order.txt $(USE_STUBS)
 	python testtools/gentest.py
 	pytest testtools/testrunner.py -k "$(shell echo $(TEST_MODULES) | sed 's/ / or /g')"

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ rmlogs:
 shell:
 	vivado -mode tcl -journal "build/logs/synth_$(BUILD_TIME).jou"  -log "build/logs/synth_$(BUILD_TIME).log"
 
-tests/stubs/generate_stubs.stamp: $(VERILOG_SOURCES)
+tests/stubs/generate_stubs.stamp: $(VERILOG_SOURCES) build/file_compile_order.txt
 	@echo "Generating typing stubs"
 	rm -rf tests/stubs
 	mkdir -p tests/stubs

--- a/tests/logic_object.py
+++ b/tests/logic_object.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass, Field
+from typing import dataclass_transform
+
+from cocotb.types import LogicArray, Range
+
+
+def concat(a: LogicArray, *arr: LogicArray) -> LogicArray:
+    arr = (a, *arr)
+
+    sizes = []
+    for x in arr:
+        sizes.append(x.range.left - x.range.right + 1)
+    total_size = sum(sizes)
+
+    new_range = Range(total_size - 1, 0)
+    result = LogicArray(0, new_range)
+
+    index = 0
+    for x, size in zip(reversed(arr), reversed(sizes)):
+        result[x.range.left + index:x.range.right + index] = x
+        index += size
+    return result
+
+
+@dataclass_transform()
+class _Meta(type):
+    def __new__(cls, *args, **kwargs):
+        cls = super().__new__(cls, *args, **kwargs)
+        return dataclass(cls)
+
+
+class LogicObject(metaclass=_Meta):    
+    @classmethod
+    def from_logicarray(cls, logic_array: LogicArray):
+        field: Field
+        values = {}
+        index = 0
+        for key, field in reversed(cls.__dataclass_fields__.items()):
+            if "size" not in field.metadata:
+                raise ValueError("Missing 'size' metadata in field")
+            size = field.metadata.get("size")
+            if not isinstance(size, int):
+                raise TypeError(f"Incorrect metadata value for 'size'. Got: '{type(size)}', expected '{int}'")
+            
+            value_type = field.metadata.get("type", "int")
+
+            sliced = logic_array[index + size - 1:index]
+
+            if value_type == "int":
+                values[key] = sliced.to_signed()
+            elif value_type == "uint":
+                values[key] = sliced.to_unsigned()
+            elif value_type == "bytes":
+                values[key] = sliced.to_bytes(byteorder="big") # TODO: expose byteorder
+            elif isinstance(value_type, type) and issubclass(value_type, LogicObject):
+                values[key] = value_type.from_logicarray(sliced)
+            else:
+                raise ValueError(f"Invalid value type '{value_type}'")
+
+            index += size
+        return cls(**values)
+
+    def to_logicarray(self) -> LogicArray:
+        arrays = []
+        field: Field
+        for key, field in self.__dataclass_fields__.items():
+            value = getattr(self, key)
+
+            if "size" not in field.metadata:
+                raise ValueError("Missing 'size' metadata in field")
+            size = field.metadata.get("size")
+            if not isinstance(size, int):
+                raise TypeError(f"Incorrect metadata value for 'size'. Got: '{type(size)}', expected '{int}'")
+            
+            if issubclass(type(value), LogicObject):
+                value = value.to_logicarray()
+            arr = LogicArray(value, Range(size - 1, 0))
+            arrays.append(arr)
+
+        if len(arrays) == 0:
+            raise ValueError("Cannot pack empty logicarray")
+
+        return concat(*arrays)

--- a/testtools/runner_tools.py
+++ b/testtools/runner_tools.py
@@ -5,6 +5,8 @@ import pytest
 import cocotb_test.simulator
 import os
 import re
+import cocotb_tools.runner
+
 
 DIR_TESTS = os.path.join(os.path.abspath("."), "tests") # TODO: ability to change path
 
@@ -48,6 +50,9 @@ def parameters_to_safe_filename(parameters: dict) -> str:
     return safe
 
 def create_test(toplevel: str, filename: str, module_name: str, testcase: str | None = None, parameters: dict[str, Any] | None = None):
+    if parameters is None:
+        parameters = {}
+
     def decorator(func):
         files = get_dependencies(toplevel)
 
@@ -64,21 +69,26 @@ def create_test(toplevel: str, filename: str, module_name: str, testcase: str | 
                 f.write(STUB_CODE)
 
             build_dir = f"build/test/simbuild_{toplevel}"
-            if parameters:
+            if len(parameters) > 0:
                 build_dir += "_" + parameters_to_safe_filename(parameters)
-
-            cocotb_test.simulator.run(
-                simulator="verilator",
-                verilog_sources=files,
-                toplevel=toplevel,
-                module=",".join(("copra.integration.autostub", module_name)),
+            runner = cocotb_tools.runner.Verilator()
+            runner.build(
+                sources=files,
+                hdl_toplevel=toplevel,
                 includes=["."],
-                compile_args=["--structs-packed", "-DSIMULATION"],
-                testcase=testcase,
-                # Different simbuild dir to utilize cache on each module
-                sim_build=build_dir, # TODO: ability to change path
-                python_search=[DIR_TESTS],
+                build_args=["--structs-packed", "-DSIMULATION", "--trace", "--trace-structs"],
+                waves=True,
+                build_dir=build_dir,
                 parameters=parameters,
+            )
+
+            runner.test(
+                hdl_toplevel=toplevel,
+                test_module=",".join(("copra.integration.autostub", module_name)),
+                testcase=testcase,
+                build_dir=build_dir,
+                test_dir=DIR_TESTS,
+                waves=True
             )
 
         return wrapper


### PR DESCRIPTION
* Automatically generate vcd waveforms in the `waveform` directory.
* Add ability to turn off stubs-generation, since it can take a lot of time, and only needs to run once interfaces change.
* Added a `LogicObject` type in `tests`. This object can automatically convert between python-types and cocotb-types. For example:


```python
from logic_object import LogicObject
class RGB(LogicObject):
    r: int = field(metadata={"size": 4, "type": "uint"})
    g: int = field(metadata={"size": 4, "type": "uint"})
    b: int = field(metadata={"size": 4, "type": "uint"})

class Triangle(LogicObject):
    x: int = field(metadata={"size": 32})
    y: int = field(metadata={"size": 32})
    z: int = field(metadata={"size": 32})
    color: RGB = field(metadata={"size": 12, "type": RGB})
```

With these classes, you can run:
```python
@cocotb.test()
def test_something(dut: SomeModule):
    # Enable the clock...

    triangle = Triangle(1,2,3, RGB(1,2,3))
    dut.triangle_input.value = triangle.to_logicarray()
    
    # Assume the verilog does triangle_output <= triangle_input
    await RisingEdge(dut.clk)
    
    triangle_out = Triangle.from_logicarray(dut.triangle_output.value)
    
    assert triangle == triangle_out
```